### PR TITLE
Ensure columns deleted are ignored

### DIFF
--- a/src/jump_profiling_recipe/preprocessing/stats.py
+++ b/src/jump_profiling_recipe/preprocessing/stats.py
@@ -235,7 +235,7 @@ def select_variant_features(
     # Select variant_features
     norm_stats = norm_stats.query("mad!=0 and abs_coef_var>1e-3")
     groups = norm_stats.groupby("Metadata_Plate", observed=True)["feature"]
-    variant_features = set.intersection(*groups.agg(set).tolist())
+    variant_features = set.intersection(set(dframe.columns), *groups.agg(set).tolist())
 
     # Select plates with variant features
     norm_stats = norm_stats.query("feature in @variant_features")


### PR DESCRIPTION
When line above: `dframe = remove_nan_infs_columns(dframe)` delete columns and those are still in `stats`, then `dframe[variant_features].values` raises an Index error because such columns are not part of `dframe`. This PR fixes it.